### PR TITLE
feat: documentation rewrite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to CryptoCipher
+
+## Development Environment
+
+CryptoCipher uses Yarn for all dependency management and testing purposes. You will be required to download and install Yarn on your operating system to develop with CryptoCipher. If you cannot download Yarn for any reason, you may use NPM. If NPM is required, ensure that no files are commited that include changes from installation with NPM to the upstream repository, as to now allow our lock file to become outdated.
+
+Generally, we use VSCode to develop for CryptoCipher. If you wish to use another IDE, please ensure that IDE specific files are not commited to the upstream repository during commits.
+
+## Husky
+
+ CryptoCipher uses [Husky Commit Hooks](https://github.com/typicode/husky) to ensure that all tests and linting standards pass at commit and push time. While this can be quite obnoxious at times, it helps to ensure that all code meets the required standards before being published.
+
+
+## ESLint Standard
+
+CryptoCipher uses ESLint to ensure that all code meets a certain expectation. We follow StandardJS's Opinionated Standard, which you can find more information for [at StandardJS's Home Page](https://standardjs.com/). This criteria is enforced both at commit time and with tests on the upstream repository for each commit and pull request. Pull Requests that fail the linting standards will not be accepted.
+
+## Commit Message Standard
+
+CryptoCipher currently loosely follows the [Conventional Commits Standard v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/), which enforced a subset of human readable commit rules to ensure that all commits meet a specific criteria. This will be mandatory in later versions of CryptoCipher with Commitlint and Husky enforcement.
+
+While creating commits, try to keep commits small (we are okay with a lot of commits vs one big commit) and to the specific sections performing work in. We also ask that you try to specify a scope specific to the section of work performed. You can find a few examples below:
+
+`feat(crypto): added check to ensure integrity of encrypted data`
+
+`docs(hash): corrected oversight in documentation for digest`
+
+`fix(drivers,crypto): driver sometimes randomly fails to request from super table for crypto`
+
+`test(crypto): added new test condition for randomly failing tests`
+
+## Mocha and Chai
+
+CryptoCipher uses Mocha and Chai for our unit testing environment. You can find more information for both of these packages [for Mocha, here](https://mochajs.org/), and [for Chai, here](https://www.chaijs.com/).

--- a/README.md
+++ b/README.md
@@ -14,40 +14,13 @@
 
 ## Installation
 
-```sh
-npm install cryptocipher@latest # for the most recent stable build
-npm install cryptocipher@next # for the most recent nightly build
-```
+You can find the installation guide, along with much more information, on our wiki!
+[GitHub Wiki and Documentation Pages](https://github.com/amethyst-studio/cryptocipher/wiki)
 
 ## Using CryptoCipher Module
 
-### Encryption and Decryption
+https://github.com/amethyst-studio/cryptocipher/wiki/Quick-Start#encryption-and-decryption
 
-```js
-
-```
-
-### Hashing
-
-```js
-
-```
-
-### Diffie-Hellman
-
-```js
-
-```
-
-### Elliptic Curve Diffie-Hellman (ECDH)
-
-```js
-
-```
-
-### HMAC
+https://github.com/amethyst-studio/cryptocipher/wiki/Quick-Start#hashing
 
 
-```js
-
-```

--- a/README.md
+++ b/README.md
@@ -12,15 +12,31 @@
 
 -------
 
+## What is CryptoCipher?
+
+Our project is a Node.js module designed to add ease of access to many encryption and hashing methods supplied by Node.js, while handling the security behind the scenes. Enforcing a standard set of secret key lengths and higher internal defaults will ensure that CryptoCipher will always provide the highest security possible to you, even if you are inexperienced with encryption yourself as a whole.
+
 ## Installation
 
 You can find the installation guide, along with much more information, on our wiki!
 [GitHub Wiki and Documentation Pages](https://github.com/amethyst-studio/cryptocipher/wiki)
 
-## Using CryptoCipher Module
+## Using the CryptoCipher Module
 
-https://github.com/amethyst-studio/cryptocipher/wiki/Quick-Start#encryption-and-decryption
+Below are some links to snippets from our Wiki, each using one of the core module of CryptoCipher. The will explaining on how to use them and provide examples of the their usage in each page.
 
-https://github.com/amethyst-studio/cryptocipher/wiki/Quick-Start#hashing
+https://github.com/amethyst-studio/cryptocipher/wiki/Quick-Start-Encryption
 
+https://github.com/amethyst-studio/cryptocipher/wiki/Quick-Start-Hashing
 
+https://github.com/amethyst-studio/cryptocipher/wiki/Quick-Start-RSA (NOT YET IMPLEMENTED)
+
+https://github.com/amethyst-studio/cryptocipher/wiki/Quick-Start-Diffie-Hellman (NOT YET IMPLEMENTED)
+
+https://github.com/amethyst-studio/cryptocipher/wiki/Quick-Start-ECDH (NOT YET IMPLEMENTED)
+
+https://github.com/amethyst-studio/cryptocipher/wiki/Quick-Start-HMAC (NOT YET IMPLEMENTED)
+
+## Contributing and Code of Conduct
+
+You can find out contribution guidelines in our [Contributing and Linting Section](CONTRIBUTING.md) and the code of conduct in [Code of Conduct and Safety Section](CODE_OF_CONDUCT.md) of our repository.


### PR DESCRIPTION
### What this PR Intends to Solve

Lack of documentation and guides for CryptoCipher.

### Goals to Solutions
- [ ] Rewrite README.md to be more informative and provide links to Wiki with extra information.
- [ ] Rewrite Wiki Pages with proper links to other Wiki Pages or Project Files.
- [ ] Add CONTRIBUTING.md for instructions on linting and tests for CryptoCipher.