### PR TITLE
merge(ch-dev/cykrix/#26): deprecate fetch() in favor of getCipher() and getHasher() respectively.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,8 @@ on:
     branches: [ master, develop ]
 
 jobs:
-  test:
+  tests:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: ubuntu-16.04
 
     strategy:

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Some major notes of this update are as follows:
 ## <center> v3.0 Cipher Integration </center>
 
 ```js
-const { fetch } = require('cryptocipher')
+const { getCipher } = require('cryptocipher')
 
 async function main () {
-  const driver = fetch('aes256')
+  const driver = getCipher('aes256')
 
   const encrypted = await driver.encrypt({
     key: '12312312312312311231231231231231',
@@ -76,10 +76,10 @@ main()
 ## <center> v3.0 Hashing Integration </center>
 
 ```js
-const { fetch } = require('cryptocipher')
+const { getHasher } = require('cryptocipher')
 
 async function main () {
-  const driver = fetch('sha256')
+  const driver = getHasher('sha256')
 
   const digest_1 = await driver.digest({
     content: 'hello world',

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -27,8 +27,39 @@ import { superify } from './super/super.cipher'
  *
  * @readonly
  * @public
+ * @deprecated This function is now deprecated and will be removed in 3.2.0, fetch() will be replaced with fetchCipher() fetchHasher() and fetch*() effective immediately.
  */
 export function fetch (identifier: string): CipherDriver | HashingDriver {
+  try {
+    return getCipher(identifier)
+  } catch (err) {
+    try {
+      return getHasher(identifier)
+    } catch (err) {
+      throw new Error('sec:violation:id_missing: This identifier was not able to be found. If you believe this is a bug, please open a report at https://github.com/amethyst-studio/cryptocipher for assistance.')
+    }
+  }
+}
+
+/**
+ * Obtain an instance of the requested CipherDriver.
+ *
+ * @remarks
+ *
+ * Acceptable identifiers are as follows:
+ * - Any entry from crypto#getCiphers()
+ *
+ * @param identifier - The requested CipherDriver implementation.
+ *
+ * @returns The preconfigured driver implementation of the specified identifier.
+ *
+ * @throws Error (sec:violation) - If the requested identifier is disabled or unsafe to use.
+ * @throws Error (sec:violation) - If the requested identifier is missing or unavailable.
+ *
+ * @readonly
+ * @public
+ */
+export function getCipher (identifier: string): CipherDriver {
   const disabled = superify().disabled
 
   // Check for Disabled
@@ -41,7 +72,28 @@ export function fetch (identifier: string): CipherDriver | HashingDriver {
     return new CipherDriver(identifier)
   }
 
-  // Check for Hashing
+  throw new Error('sec:violation:id_missing: This identifier was not able to be found. If you believe this is a bug, please open a report at https://github.com/amethyst-studio/cryptocipher for assistance.')
+}
+
+/**
+ * Obtain an instance of the requested HashingDriver.
+ *
+ * @remarks
+ *
+ * Acceptable identifiers are as follows:
+ * - Any entry from crypto#getHashes()
+ *
+ * @param identifier - The requested HashingDriver implementation.
+ *
+ * @returns The preconfigured driver implementation of the specified identifier.
+ *
+ * @throws Error (sec:violation) - If the requested identifier is missing or unavailable.
+ *
+ * @readonly
+ * @public
+ */
+export function getHasher (identifier: string): HashingDriver {
+  // Check for Hasher
   if (getHashes().includes(identifier)) {
     return new HashingDriver(identifier)
   }

--- a/tests/cipher.test.ts
+++ b/tests/cipher.test.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { getCiphers } from 'crypto';
-import { fetch } from '../src/driver';
-import { CipherDriver } from '../src/driver.cipher';
+import { getCipher } from '../src/driver';
 import { superify } from '../src/super/super.cipher';
 import { DecryptionContext, EncryptionContext } from '../src/types/driver';
 import { generate } from '../src/utils/util';
@@ -20,7 +19,7 @@ describe('Crypto#getCiphers: Testing integrity of all provided algorithms.', fun
             content: generate(2048)
           }
 
-          const driver = <CipherDriver> fetch(identifier)
+          const driver = getCipher(identifier)
           const encrypt = await driver.encrypt(t)
           const d: DecryptionContext = {
             key: t.key,

--- a/tests/hashing.test.ts
+++ b/tests/hashing.test.ts
@@ -1,13 +1,12 @@
 import { getHashes } from 'crypto';
-import { fetch } from '../src/driver';
-import { HashingDriver } from '../src/driver.hashing';
+import { getHasher } from '../src/driver';
 import { generate } from '../src/utils/util';
 
 describe('Crypto#getHashes: Testing integrity of all provided algorithms.', function () {
   for (const identifier of getHashes()) {
     it (`${identifier}: should not fail single hashing cycle (1)`, async function () {
       for (let index = 0; index < 5; index++) {
-        const driver = <HashingDriver> fetch(identifier)
+        const driver = getHasher(identifier)
         await driver.digest({
           content: generate(1024),
           digest: 'hex'
@@ -16,7 +15,7 @@ describe('Crypto#getHashes: Testing integrity of all provided algorithms.', func
     })
     it (`${identifier}: should not fail multiple hashing cycle (2048)`, async function () {
       for (let index = 0; index < 5; index++) {
-        const driver = <HashingDriver> fetch(identifier)
+        const driver = getHasher(identifier)
         await driver.digest({
           content: generate(1024),
           digest: 'hex',


### PR DESCRIPTION
Deprecation of fetch()

Closes #26 